### PR TITLE
Fix error reporting issue

### DIFF
--- a/lib/I18nExtractorPlugin.js
+++ b/lib/I18nExtractorPlugin.js
@@ -27,7 +27,7 @@ const ChunkGroup = require("webpack/lib/ChunkGroup");
 const {connectChunkGroupAndChunk} = require("webpack/lib/GraphHelpers");
 const I18nExtractorItemDependency = require("./I18nExtractorItemDependency");
 const runtime = require("./I18nExtractorPlugin.runtime");
-const {tap,callSyncWaterfall} = require("webpack-plugin-compat").for("webpack-i18n-extractor-plugin");
+const {tap, callSync, callSyncWaterfall} = require("webpack-plugin-compat").for("webpack-i18n-extractor-plugin");
 
 const BLOCK_COMMENT = "/* i18n extractor */";
 const CHUNK_REASON = "language extraction";
@@ -231,7 +231,7 @@ module.exports = class I18nExtractorPlugin {
           if (promiseMod && chunk.containsModule(promiseMod)) {
             buf.push(`__webpack_require__(${promiseMod.id} /* ${promisePath} */); ${BLOCK_COMMENT}`);
           } else {
-            throw new Error(`Error referencing promise polyfill: ${options.promisePolyfill}`);
+            callSync(compiler, 'failed', new Error(`Error referencing promise polyfill: ${promisePath}`));
           }
         }
         buf.push(`var langPromises = loadLanguageChunks(${JSON.stringify(chunk.id)});  ${BLOCK_COMMENT}`);


### PR DESCRIPTION
Error thrown in mainTemplate 'startup' hook is swallowed.  Call compiler 'failed' hook instead of throwing.